### PR TITLE
feat: github token pool + CI workflow + parseSearchParams host fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # tests/ uses the node:test runner with zero deps — no install needed.
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node --test 'tests/**/*.test.js'"
+    "test": "node --test tests/*.test.js"
   },
   "license": "MIT"
 }

--- a/src/common/github-token.js
+++ b/src/common/github-token.js
@@ -1,0 +1,125 @@
+// Token rotation for GitHub fetchers.
+//
+// A single GITHUB_TOKEN bottlenecks at 5000 GraphQL points per hour, which
+// translates to ~1000 fetchStats calls per hour for the worst case (one
+// query + four pagination pages = 5 calls). Heavy README embeds blow through
+// this in minutes.
+//
+// This module reads tokens from any of the following env shapes and exposes
+// a `nextToken()` round-robin plus an `invalidate(token)` hook so callers
+// can mark a token as exhausted (HTTP 401/403/429) and skip it for the
+// remainder of the warm process.
+//
+//   GITHUB_TOKEN                       (single)
+//   GITHUB_TOKENS                      (comma-separated list)
+//   GITHUB_TOKEN_1, GITHUB_TOKEN_2, …  (numbered)
+//
+// All shapes can be combined; duplicates are removed.
+
+const COOLDOWN_MS = 60 * 60 * 1000; // mirror GitHub's reset window
+
+let pool = null;
+
+function loadTokens() {
+  const seen = new Set();
+  const tokens = [];
+
+  const add = (raw) => {
+    if (!raw) return;
+    const t = raw.trim();
+    if (!t || seen.has(t)) return;
+    seen.add(t);
+    tokens.push({ token: t, cooldownUntil: 0 });
+  };
+
+  add(process.env.GITHUB_TOKEN);
+
+  if (process.env.GITHUB_TOKENS) {
+    for (const t of process.env.GITHUB_TOKENS.split(",")) add(t);
+  }
+
+  for (let i = 1; i < 32; i++) {
+    add(process.env[`GITHUB_TOKEN_${i}`]);
+  }
+
+  return tokens;
+}
+
+function ensurePool() {
+  if (pool) return pool;
+  pool = { tokens: loadTokens(), cursor: 0 };
+  return pool;
+}
+
+/**
+ * Returns the next usable token, or null if every token in the pool is
+ * currently in cooldown. Round-robins across calls.
+ */
+function nextToken() {
+  const p = ensurePool();
+  if (p.tokens.length === 0) return null;
+
+  const now = Date.now();
+  const start = p.cursor;
+  for (let i = 0; i < p.tokens.length; i++) {
+    const idx = (start + i) % p.tokens.length;
+    const entry = p.tokens[idx];
+    if (entry.cooldownUntil <= now) {
+      p.cursor = (idx + 1) % p.tokens.length;
+      return entry.token;
+    }
+  }
+  return null;
+}
+
+/**
+ * Mark a token as cooled-down for `ms` milliseconds (default 1h). Used by
+ * fetchers when a request fails with 401/403/429 — the same call sequence
+ * will pick a different token on its next attempt.
+ */
+function invalidate(token, ms = COOLDOWN_MS) {
+  const p = ensurePool();
+  for (const entry of p.tokens) {
+    if (entry.token === token) {
+      entry.cooldownUntil = Date.now() + ms;
+      return;
+    }
+  }
+}
+
+/**
+ * Convenience wrapper: try `fn(token)` against each available token in turn,
+ * invalidating tokens that come back with rotation-eligible status codes,
+ * and rethrowing on the final failure (or any non-rotation error).
+ */
+async function withRotation(fn) {
+  const p = ensurePool();
+  if (p.tokens.length === 0) {
+    throw new Error("GITHUB_TOKEN not configured");
+  }
+
+  let lastError;
+  for (let attempt = 0; attempt < p.tokens.length; attempt++) {
+    const token = nextToken();
+    if (!token) break;
+    try {
+      return await fn(token);
+    } catch (err) {
+      lastError = err;
+      const status = err && err.status;
+      if (status === 401 || status === 403 || status === 429) {
+        invalidate(token);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastError ?? new Error("All GitHub tokens are in cooldown");
+}
+
+// Test-only escape hatch — lets unit tests reset the pool between cases.
+function _resetForTests() {
+  pool = null;
+}
+
+module.exports = { nextToken, invalidate, withRotation, _resetForTests };

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -30,8 +30,14 @@ function readColorOverrides(params) {
   return out;
 }
 
+// Use a fixed base origin instead of `req.headers.host`. The host header is
+// untrusted in serverless environments and we only want the path + query
+// parts of `req.url` anyway, so passing a constant origin avoids any chance
+// of host-header injection ever surfacing through `searchParams`.
+const FIXED_PARSE_BASE = "http://profilekit.local";
+
 function parseSearchParams(req) {
-  return new URL(req.url, `http://${req.headers.host}`).searchParams;
+  return new URL(req.url, FIXED_PARSE_BASE).searchParams;
 }
 
 function parseCardOptions(params) {

--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -59,7 +59,11 @@ async function graphql(query, variables, token) {
   });
 
   if (!res.ok) {
-    throw new Error(`GitHub API error: ${res.status}`);
+    // Surface status so the calling token-pool can rotate on 401/403/429
+    // instead of giving up after a single per-token rate-limit hit.
+    const err = new Error(`GitHub API error: ${res.status}`);
+    err.status = res.status;
+    throw err;
   }
 
   const json = await res.json();
@@ -72,42 +76,51 @@ async function graphql(query, variables, token) {
   return json.data;
 }
 
-async function fetchStats(username, token) {
-  const data = await graphql(QUERY, { login: username }, token);
-  const user = data.user;
+const { withRotation } = require("../common/github-token");
 
-  let totalStars = user.repositories.nodes.reduce(
-    (sum, r) => sum + r.stargazerCount,
-    0
-  );
+async function fetchStats(username, _legacyToken) {
+  // The legacy second argument is ignored — token rotation now lives in
+  // src/common/github-token.js. Endpoints can still pass a token to keep
+  // the old call sites working until they migrate.
+  return withRotation(async (token) => {
+    const data = await graphql(QUERY, { login: username }, token);
+    const user = data.user;
 
-  // Paginate remaining repos (max 4 extra pages = 500 repos total)
-  let pageInfo = user.repositories.pageInfo;
-  let pages = 0;
-  while (pageInfo.hasNextPage && pages < 4) {
-    const more = await graphql(
-      REPOS_QUERY,
-      { login: username, after: pageInfo.endCursor },
-      token
+    let totalStars = user.repositories.nodes.reduce(
+      (sum, r) => sum + r.stargazerCount,
+      0
     );
-    const repos = more.user.repositories;
-    totalStars += repos.nodes.reduce((sum, r) => sum + r.stargazerCount, 0);
-    pageInfo = repos.pageInfo;
-    pages++;
-  }
 
-  return {
-    name: user.name || user.login,
-    totalCommits:
-      user.contributionsCollection.totalCommitContributions +
-      user.contributionsCollection.restrictedContributionsCount,
-    totalPRs: user.pullRequests.totalCount,
-    totalIssues:
-      user.openIssues.totalCount + user.closedIssues.totalCount,
-    totalStars,
-    totalRepos: user.repositories.totalCount,
-    contributedTo: user.repositoriesContributedTo.totalCount,
-  };
+    // Paginate remaining repos (max 4 extra pages = 500 repos total). Each
+    // page reuses the same token within one fetchStats call; rotation
+    // happens between calls, not mid-pagination.
+    let pageInfo = user.repositories.pageInfo;
+    let pages = 0;
+    while (pageInfo.hasNextPage && pages < 4) {
+      const more = await graphql(
+        REPOS_QUERY,
+        { login: username, after: pageInfo.endCursor },
+        token
+      );
+      const repos = more.user.repositories;
+      totalStars += repos.nodes.reduce((sum, r) => sum + r.stargazerCount, 0);
+      pageInfo = repos.pageInfo;
+      pages++;
+    }
+
+    return {
+      name: user.name || user.login,
+      totalCommits:
+        user.contributionsCollection.totalCommitContributions +
+        user.contributionsCollection.restrictedContributionsCount,
+      totalPRs: user.pullRequests.totalCount,
+      totalIssues:
+        user.openIssues.totalCount + user.closedIssues.totalCount,
+      totalStars,
+      totalRepos: user.repositories.totalCount,
+      contributedTo: user.repositoriesContributedTo.totalCount,
+    };
+  });
 }
 
 module.exports = { fetchStats };


### PR DESCRIPTION
## Summary
- **GitHub token pool** (\`src/common/github-token.js\`, new): reads any of \`GITHUB_TOKEN\`, \`GITHUB_TOKENS\` (comma-separated), or \`GITHUB_TOKEN_1..31\` and exposes \`nextToken\` / \`invalidate\` / \`withRotation\`. Responses with 401/403/429 push the offending token into an in-memory 1h cooldown, and the next attempt picks a different token from the round-robin. Raises the old 1000 fetchStats/hour ceiling linearly with pool size.
- **fetchStats rotation**: \`src/fetchers/stats.js\` wraps its GraphQL work in \`withRotation\`. Per-page pagination keeps the same token within a single call (rotation happens between calls). The old second positional argument survives as a no-op so endpoints that still pass a token keep working.
- **parseSearchParams host fix**: \`src/common/options.js\` uses a fixed base origin instead of \`http://\${req.headers.host}\`. The host header is untrusted in serverless and we only need the path/query portions of \`req.url\`, so host-header injection is off the reachable surface.
- **CI workflow** (\`.github/workflows/ci.yml\`, new): runs \`npm test\` on push and pull_request against main. Node 20, no install step — tests use node:test with zero deps.

Closes review.md P1 (single-token rate limit, CI absence) and P2 (host header trust).

## Test plan
- [ ] \`npm test\` passes locally and in the new CI workflow.
- [ ] With a single \`GITHUB_TOKEN\` the behavior is unchanged (pool size 1 → rotation loop runs once).
- [ ] With \`GITHUB_TOKEN_1 / GITHUB_TOKEN_2\` set, manually force a 429 on token 1 → next call uses token 2.
- [ ] All tokens in cooldown → request surfaces \`All GitHub tokens are in cooldown\`.