### PR TITLE
refactor: consolidate 28 api functions into single router

### DIFF
--- a/api/[name].js
+++ b/api/[name].js
@@ -1,0 +1,45 @@
+const ENDPOINT_NAMES = [
+  "constellation",
+  "divider",
+  "equalizer",
+  "glitch",
+  "health",
+  "heartbeat",
+  "hero",
+  "languages",
+  "leetcode",
+  "matrix",
+  "neon",
+  "now",
+  "pin",
+  "posts",
+  "quote",
+  "radar",
+  "reviews",
+  "section",
+  "snake",
+  "social",
+  "stack",
+  "stats",
+  "tags",
+  "terminal",
+  "timeline",
+  "toc",
+  "typing",
+  "wave",
+];
+
+const ALLOWED = new Set(ENDPOINT_NAMES);
+
+module.exports = async (req, res) => {
+  const name = req.query && req.query.name;
+  if (!name || !ALLOWED.has(name)) {
+    res.status(404).setHeader("Content-Type", "text/plain");
+    return res.send(`Unknown endpoint: ${name ?? "(missing)"}`);
+  }
+
+  const handler = require(`../src/endpoints/${name}`);
+  return handler(req, res);
+};
+
+module.exports.ALLOWED_ENDPOINTS = ENDPOINT_NAMES;

--- a/src/endpoints/constellation.js
+++ b/src/endpoints/constellation.js
@@ -1,11 +1,11 @@
-const { renderConstellationCard } = require("../src/cards/constellation");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderConstellationCard } = require("../cards/constellation");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseColor,
   parseFloatSafe,
   parseIntSafe,
   cacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/divider.js
+++ b/src/endpoints/divider.js
@@ -1,18 +1,17 @@
-const { renderWaveCard } = require("../src/cards/wave");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderDividerCard } = require("../cards/divider");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
   const { opts, themeError } = await resolveCardOptions(params);
 
-  const svg = renderWaveCard({
+  const svg = renderDividerCard({
     ...opts,
-    text: params.get("text"),
+    style: params.get("style") || "line",
     color: parseColor(params.get("color")),
     width: parseIntSafe(params.get("width"), 800),
-    height: parseIntSafe(params.get("height"), 160),
-    waves: parseIntSafe(params.get("waves"), 3),
+    height: parseIntSafe(params.get("height"), 30),
   });
 
   res.setHeader("Content-Type", "image/svg+xml");

--- a/src/endpoints/equalizer.js
+++ b/src/endpoints/equalizer.js
@@ -1,6 +1,6 @@
-const { renderEqualizerCard } = require("../src/cards/equalizer");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderEqualizerCard } = require("../cards/equalizer");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/glitch.js
+++ b/src/endpoints/glitch.js
@@ -1,6 +1,6 @@
-const { renderGlitchCard } = require("../src/cards/glitch");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderGlitchCard } = require("../cards/glitch");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/health.js
+++ b/src/endpoints/health.js
@@ -8,9 +8,9 @@
 // monitoring can decide its own severity (zero-token is a warning, not an
 // outage, because pure cards like /api/hero still work).
 
-const { poolStats } = require("../src/common/github-token");
-const { ALLOWED_FEED_HOSTS } = require("../src/fetchers/posts");
-const { ALLOWED_HOSTS: ALLOWED_THEME_URL_HOSTS } = require("../src/common/theme-url");
+const { poolStats } = require("../common/github-token");
+const { ALLOWED_FEED_HOSTS } = require("../fetchers/posts");
+const { ALLOWED_HOSTS: ALLOWED_THEME_URL_HOSTS } = require("../common/theme-url");
 
 module.exports = async (req, res) => {
   const pool = poolStats();

--- a/src/endpoints/heartbeat.js
+++ b/src/endpoints/heartbeat.js
@@ -1,6 +1,6 @@
-const { renderHeartbeatCard } = require("../src/cards/heartbeat");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderHeartbeatCard } = require("../cards/heartbeat");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/hero.js
+++ b/src/endpoints/hero.js
@@ -1,6 +1,6 @@
-const { renderHeroCard } = require("../src/cards/hero");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderHeroCard } = require("../cards/hero");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/languages.js
+++ b/src/endpoints/languages.js
@@ -1,7 +1,7 @@
-const { fetchLanguages } = require("../src/fetchers/languages");
-const { renderLanguagesCard } = require("../src/cards/languages");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchLanguages } = require("../fetchers/languages");
+const { renderLanguagesCard } = require("../cards/languages");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseBoolean,
   parseArray,
@@ -9,7 +9,7 @@ const {
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/leetcode.js
+++ b/src/endpoints/leetcode.js
@@ -1,13 +1,12 @@
-const { fetchStats } = require("../src/fetchers/stats");
-const { renderStatsCard } = require("../src/cards/stats");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchLeetcode } = require("../fetchers/leetcode");
+const { renderLeetcodeCard } = require("../cards/leetcode");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
-  parseArray,
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
@@ -15,8 +14,6 @@ module.exports = async (req, res) => {
   const { colors, font } = opts;
 
   const username = params.get("username");
-  const hide = parseArray(params.get("hide"));
-  const layout = params.get("layout");
 
   res.setHeader("Content-Type", "image/svg+xml");
   if (themeError) res.setHeader("X-Theme-Error", themeError);
@@ -27,11 +24,8 @@ module.exports = async (req, res) => {
   }
 
   try {
-    // Token pool handling lives in src/common/github-token via withRotation
-    // inside fetchStats — missing/invalid/rate-limited tokens are surfaced
-    // here as thrown errors and rendered as the error card.
-    const stats = await fetchStats(username);
-    const svg = renderStatsCard(stats, { ...opts, hide, layout });
+    const stats = await fetchLeetcode(username);
+    const svg = renderLeetcodeCard(stats, opts);
 
     res.setHeader("Cache-Control", cacheHeaders());
     return res.send(svg);

--- a/src/endpoints/matrix.js
+++ b/src/endpoints/matrix.js
@@ -1,25 +1,25 @@
-const { renderRadarCard } = require("../src/cards/radar");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderMatrixCard } = require("../cards/matrix");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseColor,
   parseFloatSafe,
   parseIntSafe,
   cacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
   const { opts, themeError } = await resolveCardOptions(params);
 
-  const svg = renderRadarCard({
+  const svg = renderMatrixCard({
     ...opts,
     text: params.get("text"),
     color: parseColor(params.get("color")),
-    width: parseIntSafe(params.get("width"), 300),
-    height: parseIntSafe(params.get("height"), 300),
-    blips: parseIntSafe(params.get("blips"), 5),
-    speed: parseFloatSafe(params.get("speed"), 4),
-    seed: parseIntSafe(params.get("seed"), 23),
+    width: parseIntSafe(params.get("width"), 600),
+    height: parseIntSafe(params.get("height"), 200),
+    density: parseFloatSafe(params.get("density"), 1),
+    speed: parseFloatSafe(params.get("speed"), 1),
+    seed: parseIntSafe(params.get("seed"), 42),
   });
 
   res.setHeader("Content-Type", "image/svg+xml");

--- a/src/endpoints/neon.js
+++ b/src/endpoints/neon.js
@@ -1,6 +1,6 @@
-const { renderNeonCard } = require("../src/cards/neon");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderNeonCard } = require("../cards/neon");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/now.js
+++ b/src/endpoints/now.js
@@ -1,6 +1,6 @@
-const { renderNowCard, NOW_FIELDS } = require("../src/cards/now");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { cacheHeaders } = require("../src/common/utils");
+const { renderNowCard, NOW_FIELDS } = require("../cards/now");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/pin.js
+++ b/src/endpoints/pin.js
@@ -1,12 +1,12 @@
-const { fetchRepo } = require("../src/fetchers/pin");
-const { renderPinCard } = require("../src/cards/pin");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchRepo } = require("../fetchers/pin");
+const { renderPinCard } = require("../cards/pin");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/posts.js
+++ b/src/endpoints/posts.js
@@ -1,13 +1,13 @@
-const { fetchPosts } = require("../src/fetchers/posts");
-const { renderPostsCard } = require("../src/cards/posts");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchPosts } = require("../fetchers/posts");
+const { renderPostsCard } = require("../cards/posts");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseIntSafe,
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/quote.js
+++ b/src/endpoints/quote.js
@@ -1,7 +1,7 @@
-const { getRandomQuote, getDailyQuote } = require("../src/data/quotes");
-const { renderQuoteCard } = require("../src/cards/quote");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseBoolean, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { getRandomQuote, getDailyQuote } = require("../data/quotes");
+const { renderQuoteCard } = require("../cards/quote");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseBoolean, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/radar.js
+++ b/src/endpoints/radar.js
@@ -1,25 +1,25 @@
-const { renderMatrixCard } = require("../src/cards/matrix");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderRadarCard } = require("../cards/radar");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseColor,
   parseFloatSafe,
   parseIntSafe,
   cacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
   const { opts, themeError } = await resolveCardOptions(params);
 
-  const svg = renderMatrixCard({
+  const svg = renderRadarCard({
     ...opts,
     text: params.get("text"),
     color: parseColor(params.get("color")),
-    width: parseIntSafe(params.get("width"), 600),
-    height: parseIntSafe(params.get("height"), 200),
-    density: parseFloatSafe(params.get("density"), 1),
-    speed: parseFloatSafe(params.get("speed"), 1),
-    seed: parseIntSafe(params.get("seed"), 42),
+    width: parseIntSafe(params.get("width"), 300),
+    height: parseIntSafe(params.get("height"), 300),
+    blips: parseIntSafe(params.get("blips"), 5),
+    speed: parseFloatSafe(params.get("speed"), 4),
+    seed: parseIntSafe(params.get("seed"), 23),
   });
 
   res.setHeader("Content-Type", "image/svg+xml");

--- a/src/endpoints/reviews.js
+++ b/src/endpoints/reviews.js
@@ -1,12 +1,12 @@
-const { fetchLeetcode } = require("../src/fetchers/leetcode");
-const { renderLeetcodeCard } = require("../src/cards/leetcode");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchReviews } = require("../fetchers/reviews");
+const { renderReviewsCard } = require("../cards/reviews");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
@@ -24,8 +24,9 @@ module.exports = async (req, res) => {
   }
 
   try {
-    const stats = await fetchLeetcode(username);
-    const svg = renderLeetcodeCard(stats, opts);
+    // Token pool resolution lives inside fetchReviews via withRotation.
+    const stats = await fetchReviews(username);
+    const svg = renderReviewsCard(stats, opts);
 
     res.setHeader("Cache-Control", cacheHeaders());
     return res.send(svg);

--- a/src/endpoints/section.js
+++ b/src/endpoints/section.js
@@ -1,6 +1,6 @@
-const { renderSectionCard } = require("../src/cards/section");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderSectionCard } = require("../cards/section");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/snake.js
+++ b/src/endpoints/snake.js
@@ -1,11 +1,11 @@
-const { renderSnakeCard } = require("../src/cards/snake");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderSnakeCard } = require("../cards/snake");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseColor,
   parseFloatSafe,
   parseIntSafe,
   cacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/social.js
+++ b/src/endpoints/social.js
@@ -1,7 +1,7 @@
-const { renderSocialCard } = require("../src/cards/social");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { cacheHeaders, errorCacheHeaders } = require("../src/common/utils");
+const { renderSocialCard } = require("../cards/social");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { cacheHeaders, errorCacheHeaders } = require("../common/utils");
 
 function parseLinks(params) {
   const types = {

--- a/src/endpoints/stack.js
+++ b/src/endpoints/stack.js
@@ -4,32 +4,32 @@
 // list and syntax are documented in the README "Composition" section; the
 // authoritative supported list is `SUPPORTED_CARDS` (= keys of `BUILDERS`).
 
-const { renderHeroCard } = require("../src/cards/hero");
-const { renderSectionCard } = require("../src/cards/section");
-const { renderDividerCard } = require("../src/cards/divider");
-const { renderNowCard, NOW_FIELDS } = require("../src/cards/now");
-const { renderTimelineCard } = require("../src/cards/timeline");
-const { renderTagsCard } = require("../src/cards/tags");
-const { renderTocCard } = require("../src/cards/toc");
-const { renderStatsCard } = require("../src/cards/stats");
-const { renderLanguagesCard } = require("../src/cards/languages");
+const { renderHeroCard } = require("../cards/hero");
+const { renderSectionCard } = require("../cards/section");
+const { renderDividerCard } = require("../cards/divider");
+const { renderNowCard, NOW_FIELDS } = require("../cards/now");
+const { renderTimelineCard } = require("../cards/timeline");
+const { renderTagsCard } = require("../cards/tags");
+const { renderTocCard } = require("../cards/toc");
+const { renderStatsCard } = require("../cards/stats");
+const { renderLanguagesCard } = require("../cards/languages");
 
-const { fetchStats } = require("../src/fetchers/stats");
-const { fetchLanguages } = require("../src/fetchers/languages");
+const { fetchStats } = require("../fetchers/stats");
+const { fetchLanguages } = require("../fetchers/languages");
 
-const { renderError } = require("../src/common/card");
-const { stackVertical } = require("../src/common/stack");
+const { renderError } = require("../common/card");
+const { stackVertical } = require("../common/stack");
 const {
   parseSearchParams,
   resolveCardOptions,
-} = require("../src/common/options");
+} = require("../common/options");
 const {
   parseArray,
   parseColor,
   parseIntSafe,
   cacheHeaders,
   errorCacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 const BUILDERS = {
   hero: async (params, opts) =>

--- a/src/endpoints/stats.js
+++ b/src/endpoints/stats.js
@@ -1,12 +1,13 @@
-const { fetchReviews } = require("../src/fetchers/reviews");
-const { renderReviewsCard } = require("../src/cards/reviews");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { fetchStats } = require("../fetchers/stats");
+const { renderStatsCard } = require("../cards/stats");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
+  parseArray,
   cacheHeaders,
   errorCacheHeaders,
   classifyError,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
@@ -14,6 +15,8 @@ module.exports = async (req, res) => {
   const { colors, font } = opts;
 
   const username = params.get("username");
+  const hide = parseArray(params.get("hide"));
+  const layout = params.get("layout");
 
   res.setHeader("Content-Type", "image/svg+xml");
   if (themeError) res.setHeader("X-Theme-Error", themeError);
@@ -24,9 +27,11 @@ module.exports = async (req, res) => {
   }
 
   try {
-    // Token pool resolution lives inside fetchReviews via withRotation.
-    const stats = await fetchReviews(username);
-    const svg = renderReviewsCard(stats, opts);
+    // Token pool handling lives in src/common/github-token via withRotation
+    // inside fetchStats — missing/invalid/rate-limited tokens are surfaced
+    // here as thrown errors and rendered as the error card.
+    const stats = await fetchStats(username);
+    const svg = renderStatsCard(stats, { ...opts, hide, layout });
 
     res.setHeader("Cache-Control", cacheHeaders());
     return res.send(svg);

--- a/src/endpoints/tags.js
+++ b/src/endpoints/tags.js
@@ -1,6 +1,6 @@
-const { renderTagsCard } = require("../src/cards/tags");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { cacheHeaders } = require("../src/common/utils");
+const { renderTagsCard } = require("../cards/tags");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/terminal.js
+++ b/src/endpoints/terminal.js
@@ -1,11 +1,11 @@
-const { renderTerminalCard } = require("../src/cards/terminal");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderTerminalCard } = require("../cards/terminal");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseColor,
   parseIntSafe,
   parseArray,
   cacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/timeline.js
+++ b/src/endpoints/timeline.js
@@ -1,6 +1,6 @@
-const { renderTimelineCard } = require("../src/cards/timeline");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { cacheHeaders } = require("../src/common/utils");
+const { renderTimelineCard } = require("../cards/timeline");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/toc.js
+++ b/src/endpoints/toc.js
@@ -1,6 +1,6 @@
-const { renderTocCard } = require("../src/cards/toc");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { cacheHeaders } = require("../src/common/utils");
+const { renderTocCard } = require("../cards/toc");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/typing.js
+++ b/src/endpoints/typing.js
@@ -1,6 +1,6 @@
-const { renderTypingCard } = require("../src/cards/typing");
-const { renderError } = require("../src/common/card");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
+const { renderTypingCard } = require("../cards/typing");
+const { renderError } = require("../common/card");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
 const {
   parseBoolean,
   parseColor,
@@ -8,7 +8,7 @@ const {
   parseIntSafe,
   cacheHeaders,
   errorCacheHeaders,
-} = require("../src/common/utils");
+} = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);

--- a/src/endpoints/wave.js
+++ b/src/endpoints/wave.js
@@ -1,17 +1,18 @@
-const { renderDividerCard } = require("../src/cards/divider");
-const { parseSearchParams, resolveCardOptions } = require("../src/common/options");
-const { parseColor, parseIntSafe, cacheHeaders } = require("../src/common/utils");
+const { renderWaveCard } = require("../cards/wave");
+const { parseSearchParams, resolveCardOptions } = require("../common/options");
+const { parseColor, parseIntSafe, cacheHeaders } = require("../common/utils");
 
 module.exports = async (req, res) => {
   const params = parseSearchParams(req);
   const { opts, themeError } = await resolveCardOptions(params);
 
-  const svg = renderDividerCard({
+  const svg = renderWaveCard({
     ...opts,
-    style: params.get("style") || "line",
+    text: params.get("text"),
     color: parseColor(params.get("color")),
     width: parseIntSafe(params.get("width"), 800),
-    height: parseIntSafe(params.get("height"), 30),
+    height: parseIntSafe(params.get("height"), 160),
+    waves: parseIntSafe(params.get("waves"), 3),
   });
 
   res.setHeader("Content-Type", "image/svg+xml");

--- a/tests/stack.test.js
+++ b/tests/stack.test.js
@@ -7,7 +7,7 @@ const {
   stackVertical,
 } = require("../src/common/stack");
 
-const { buildStack, scopeParams, SUPPORTED_CARDS } = require("../api/stack");
+const { buildStack, scopeParams, SUPPORTED_CARDS } = require("../src/endpoints/stack");
 
 const SAMPLE_SVG_A = `<svg xmlns="http://www.w3.org/2000/svg" width="495" height="200" viewBox="0 0 495 200">
   <defs>
@@ -213,7 +213,7 @@ test("buildStack renders inline error when stats requires a token pool that's em
 });
 
 test("buildStack refuses to render more cards than MAX_CARDS_PER_STACK", async () => {
-  const { MAX_CARDS_PER_STACK } = require("../api/stack");
+  const { MAX_CARDS_PER_STACK } = require("../src/endpoints/stack");
   const tooMany = Array(MAX_CARDS_PER_STACK + 1).fill("divider").join(",");
   const params = new URLSearchParams(`cards=${tooMany}`);
   const { svg, ok } = await buildStack(params);


### PR DESCRIPTION
## Summary

Vercel Hobby plan caps Serverless Functions at 12 per deployment. After `hero/snake/section/divider/health` landed we silently exceeded the cap. **No production deploys had landed since 2026-04-04** — those endpoints returned 404.

This PR collapses every handler into a single `api/[name].js` router with an explicit allowlist. Every endpoint moves to `src/endpoints/`.

## Changes

- `api/*.js` (28 files) → `src/endpoints/*.js`
- New `api/[name].js` — single dynamic route, validates against explicit allowlist, dispatches via `require`
- Require paths in moved files drop the redundant `../src/` prefix
- `tests/stack.test.js` import path updated

## Verification

- [x] `npm test` — 158/158 pass
- [x] `vercel --prod` — deploys successfully (previously failed at deploy step)
- [x] `/api/health`, `/api/hero`, `/api/snake`, `/api/section`, `/api/divider`, `/api/stats` all return 200 with correct content-type

## Impact

- Hobby-plan compatible → anyone can fork and self-host without Pro
- Public URLs unchanged — fully backwards compatible
- One function means one cold-start path instead of 28