### PR TITLE
fix(router): rename [name] segment to [endpoint]

### DIFF
--- a/api/[endpoint].js
+++ b/api/[endpoint].js
@@ -32,13 +32,17 @@ const ENDPOINT_NAMES = [
 const ALLOWED = new Set(ENDPOINT_NAMES);
 
 module.exports = async (req, res) => {
-  const name = req.query && req.query.name;
-  if (!name || !ALLOWED.has(name)) {
+  // The dynamic segment is named [endpoint], not [name], on purpose:
+  // some handlers (hero, now, etc.) expect ?name= as a legitimate user
+  // parameter, and Vercel merges the captured segment into req.query.
+  // Using [endpoint] avoids clobbering ?name= at the URLSearchParams level.
+  const endpoint = req.query && req.query.endpoint;
+  if (!endpoint || !ALLOWED.has(endpoint)) {
     res.status(404).setHeader("Content-Type", "text/plain");
-    return res.send(`Unknown endpoint: ${name ?? "(missing)"}`);
+    return res.send(`Unknown endpoint: ${endpoint ?? "(missing)"}`);
   }
 
-  const handler = require(`../src/endpoints/${name}`);
+  const handler = require(`../src/endpoints/${endpoint}`);
   return handler(req, res);
 };
 


### PR DESCRIPTION
## Problem

The refactor in #2 introduced \`api/[name].js\` as the single dispatcher. But Vercel merges the captured segment into \`req.query\`, which means URLSearchParams on \`req.url\` sees two \`name=\` values — the segment and the user's query — and returns the segment (which is the endpoint identifier, e.g. \`hero\`).

Result: \`/api/hero?name=heznpc\` rendered **"hero"** as the hero title instead of "heznpc". Same latent bug on any other handler that reads \`?name=\` (now, typing, possibly more).

## Fix

Rename the dynamic segment \`[name]\` → \`[endpoint]\`. No endpoint's user-facing params use \`?endpoint=\`, so this avoids the clobber.

## Verification

Before:
\`\`\`
$ curl '.../api/hero?name=heznpc' | grep hero-name
<text class="hero-name">hero</text>
\`\`\`

After:
\`\`\`
$ curl '.../api/hero?name=heznpc' | grep hero-name
<text class="hero-name">heznpc</text>
\`\`\`