### PR TITLE
rebrand: reposition as the human craft layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,31 @@
 # ProfileKit
 
 <p align="center">
-  <img src="https://profilekit.vercel.app/api/hero?name=ProfileKit&subtitle=All-in-one+GitHub+profile+cards.+Designer+typography.&bg=wave&width=900&height=240&font=inter" alt="ProfileKit" />
+  <img src="https://profilekit.vercel.app/api/hero?name=ProfileKit&subtitle=Craft+your+GitHub+profile.+The+human+layer.&bg=gradient&width=900&height=220&font=space-grotesk" alt="ProfileKit" />
 </p>
 
-Developer personal brand visuals as composable SVG. Stats, languages, blog-layout primitives, animations, and five bundled designer fonts — no ratings, no rankings, just clean customizable cards.
+**Craft your GitHub profile — the human layer on top of AI-generated defaults.**
+
+AI makes "nice" easy. ProfileKit makes it *yours*: 28 composable SVG cards, every visual property editable, share your craft through URL-encoded presets. Think Sims 3 Create-A-Style — for developer profiles.
 
 One service, many contexts. The same card renders in your GitHub README, your dev.to bio, your Hashnode post header, or your slide cover. Deploy once on Vercel, use everywhere.
 
 <p align="center">
   <img src="https://profilekit.vercel.app/api/divider?style=wave&width=900" alt="" />
+</p>
+
+## Why ProfileKit
+
+AI generators nail "nice." They struggle with "yours." The thesis in three lines:
+
+- **Constrained creativity beats blank canvas.** Figma is too open (blank-canvas paralysis). AI prompts are too closed (your voice gets absorbed into the training set). ProfileKit sits in between — fixed components (hero, stats, snake, ...), every visual property editable.
+- **Craft as identity.** Your profile is the first thing other devs see. It should feel like *you* made it — even if the content is "just" stats + languages.
+- **Share your craft.** Roadmap v2 adds shareable URL presets ("looks"). v4 adds **The Exchange** — a community registry where devs post their looks and remix each other's. Sims 3 CAS + The Exchange, for developer profile walls.
+
+ProfileKit doesn't replace AI design tools. It's what you reach for when *"nice"* isn't enough.
+
+<p align="center">
+  <img src="https://profilekit.vercel.app/api/divider?style=dots&width=900" alt="" />
 </p>
 
 ## Data Cards

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "profilekit",
   "version": "1.0.0",
   "private": true,
-  "description": "All-in-one GitHub profile cards — stats, languages, activity, contributions, repos, typing, quotes, social, leetcode",
+  "description": "Craft your GitHub profile. The human layer on top of AI-generated defaults — 28 composable SVG cards, every visual property editable.",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary

Reposition ProfileKit from "generic profile card builder" to **"the human craft layer on top of AI-generated defaults."**

## What changes

- **Tagline** (hero banner + first line of README):
  - Before: _"All-in-one GitHub profile cards. Designer typography."_
  - After: _"Craft your GitHub profile. The human layer."_
- **New "Why ProfileKit" section** right after the intro. Three-bullet thesis:
  1. Constrained creativity beats blank canvas (Figma/AI axes).
  2. Craft as identity.
  3. Share your craft → future community exchange.
- **package.json description** updated to match.

## What does NOT change

- No feature docs removed
- No anti-AI stance — positioning is complementary: "AI nails 'nice'; we nail 'yours'"
- No visual redesign of the rest of the README — only the opener

## Why now

Earlier research in this direction (community registry / Sims 3 CAS analog) showed the empty niche is "user-authored + shared craft" in a market where everything else is converging on AI-default generation. Positioning statement should lead product roadmap (shareable URL presets v2 → direct-manipulation editor v3 → The Exchange v4) — so the README thesis gets stated first, features follow.