### PR TITLE
chore: bump node engine to >=20

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Craft your GitHub profile. The human layer on top of AI-generated defaults — 28 composable SVG cards, every visual property editable.",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "test": "node --test tests/*.test.js"


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=18` to `>=20`. Node 18 went EOL on 2025-04-30; CI already uses Node 20.
- Aligns declared support with what's actually tested and runtime on Vercel.

## Test plan
- [x] `npm test` — all 158 tests pass.
- [x] CI (`.github/workflows/ci.yml`) already pins `node-version: '20'`.