### PR TITLE
feat(composer): v3.4.1 — inline edit on stats / pin / languages (closes #29)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1748,8 +1748,12 @@ function persistAndRender() {
 // pane (full inline contenteditable on SVG <text> is browser-flaky;
 // click-to-jump is the v3.4 MVP, real text-in-canvas edit lives in v3.4.x).
 
-async function injectHeroSvg(container, slots, blockIndex) {
-  const url = buildCardUrlForCompose("hero", slots);
+// Card types that ship inline-edit hooks (data-cas-target attributes in
+// their SVG output) — render as inline <svg> in the canvas instead of <img>.
+const INLINE_EDIT_CARDS = new Set(["hero", "stats", "languages", "pin"]);
+
+async function injectCardSvg(container, cardType, slots, blockIndex) {
+  const url = buildCardUrlForCompose(cardType, slots);
   let svgText;
   try {
     const res = await fetch(url);
@@ -1769,18 +1773,20 @@ async function injectHeroSvg(container, slots, blockIndex) {
   }
   container.innerHTML = "";
   container.appendChild(svg);
-  attachCasHandlers(svg, blockIndex);
+  attachCasHandlers(svg, cardType, blockIndex);
 }
 
-function attachCasHandlers(svg, blockIndex) {
+function attachCasHandlers(svg, cardType, blockIndex) {
   svg.querySelectorAll("[data-cas-target]").forEach((target) => {
     const slotName = target.getAttribute("data-cas-target");
     target.addEventListener("click", (e) => {
       e.stopPropagation();
       selectBlock(blockIndex);
-      if (slotName === "bg") {
+      // bg picker is hero-specific. Everything else is text-ish — focus the
+      // matching slot input in the right pane and let the user edit there.
+      if (cardType === "hero" && slotName === "bg") {
         showBgPopover(target, blockIndex);
-      } else if (slotName === "name" || slotName === "subtitle") {
+      } else {
         focusSlotInput(slotName);
       }
     });
@@ -1940,12 +1946,11 @@ function renderBlocks() {
     body.className = "block-body";
 
     if (block.type === "card") {
-      if (block.card_type === "hero") {
-        // v3.4 — hero alone gets inline-SVG so click-to-edit hit regions
-        // can attach. Other card types still render as <img> (no inline
-        // editing on them yet).
+      if (INLINE_EDIT_CARDS.has(block.card_type)) {
+        // Cards that emit data-cas-target hooks render inline so click-to-edit
+        // handlers can attach. Other card types still render as <img>.
         body.innerHTML = '<div class="hero-loading">loading…</div>';
-        injectHeroSvg(body, block.slots, index);
+        injectCardSvg(body, block.card_type, block.slots, index);
       } else {
         const img = document.createElement("img");
         img.src = buildCardUrlForCompose(block.card_type, block.slots);

--- a/src/cards/languages.js
+++ b/src/cards/languages.js
@@ -35,7 +35,7 @@ function renderDefault(languages, { colors, hideBorder, hideTitle, hideBar, bord
     })
     .join("\n  ");
 
-  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: rows, font });
+  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: rows, font, titleTarget: "username" });
 }
 
 function renderCompact(languages, { colors, hideBorder, hideTitle, hideBar, borderRadius, cardTitle, cardWidth, font }) {
@@ -82,7 +82,7 @@ function renderCompact(languages, { colors, hideBorder, hideTitle, hideBar, bord
   const legendRows = Math.ceil(languages.length / 4);
   const totalHeight = startY + 24 + legendRows * 20 + 12;
 
-  return renderCard({ width, height: totalHeight, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: `${barGroup}\n  ${legendItems}`, font });
+  return renderCard({ width, height: totalHeight, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: `${barGroup}\n  ${legendItems}`, font, titleTarget: "username" });
 }
 
 function renderDonut(languages, { colors, hideBorder, hideTitle, hideBar, borderRadius, cardTitle, cardWidth, font }) {
@@ -134,7 +134,7 @@ function renderDonut(languages, { colors, hideBorder, hideTitle, hideBar, border
     ${segments}
     ${legendItems}`;
 
-  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body, font });
+  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body, font, titleTarget: "username" });
 }
 
 module.exports = { renderLanguagesCard };

--- a/src/cards/pin.js
+++ b/src/cards/pin.js
@@ -55,19 +55,22 @@ function renderPinCard(repo, { colors, hideBorder, hideBar, borderRadius, cardWi
   const height = footerY + 30;
 
   const nameMarkup = `
-    <g transform="translate(25, ${nameY})">
+    <g transform="translate(25, ${nameY})" data-cas-target="repo">
       <svg x="0" y="-12" viewBox="0 0 16 16" width="16" height="16" fill="${colors.icon}">
         ${icons.repos}
       </svg>
       <text x="22" y="0" class="header">${escapeHtml(repo.name)}</text>
     </g>`;
 
-  const descMarkup = descLines
+  const descLineMarkup = descLines
     .map((line, i) => {
       const y = descStartY + i * descLineHeight;
       return `<text x="25" y="${y}" class="stat-label">${escapeHtml(line)}</text>`;
     })
-    .join("\n    ");
+    .join("\n      ");
+  const descMarkup = descLines.length
+    ? `<g data-cas-target="description">\n      ${descLineMarkup}\n    </g>`
+    : "";
 
   // Layout the footer left-to-right but reserve space for stars/forks first so
   // a long language name gets truncated rather than pushing them off-card.

--- a/src/cards/stats.js
+++ b/src/cards/stats.js
@@ -47,7 +47,7 @@ function renderDefault(stats, visible, { colors, hideBorder, hideTitle, hideBar,
     })
     .join("\n  ");
 
-  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: rows, font });
+  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: rows, font, titleTarget: "username" });
 }
 
 function renderCompact(stats, visible, { colors, hideBorder, hideTitle, hideBar, borderRadius, cardTitle, cardWidth, font }) {
@@ -79,7 +79,7 @@ function renderCompact(stats, visible, { colors, hideBorder, hideTitle, hideBar,
     })
     .join("\n  ");
 
-  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: cells, font });
+  return renderCard({ width, height, title: cardTitle, colors, hideBorder, hideTitle, hideBar, borderRadius, body: cells, font, titleTarget: "username" });
 }
 
 module.exports = { renderStatsCard };

--- a/src/common/card.js
+++ b/src/common/card.js
@@ -45,13 +45,16 @@ function buildAccentStops(colors) {
     .join("\n      ");
 }
 
-function renderCard({ width, height, title, ariaLabel, colors, hideBorder, hideTitle, hideBar, borderRadius, body, font }) {
+function renderCard({ width, height, title, ariaLabel, colors, hideBorder, hideTitle, hideBar, borderRadius, body, font, titleTarget }) {
   const rx = borderRadius != null ? borderRadius : 6;
   const { embedCss, family } = resolveFont(font);
 
+  // titleTarget is an optional data-cas-target hook for the playground
+  // composer's inline-edit feature. Pure HTML attribute, no visual effect.
+  const titleAttr = titleTarget ? ` data-cas-target="${titleTarget}"` : "";
   const titleMarkup = hideTitle
     ? ""
-    : `<text x="25" y="35" class="header">${escapeHtml(title)}</text>`;
+    : `<text x="25" y="35" class="header"${titleAttr}>${escapeHtml(title)}</text>`;
 
   const accentStops = buildAccentStops(colors);
 


### PR DESCRIPTION
Adds data-cas-target hooks to stats, languages (via new titleTarget arg in renderCard), and pin (repo + description). Playground generalizes to INLINE_EDIT_CARDS set. Click-to-jump-to-slot-input pattern. See #29.