### PR TITLE
chore: modernize CI, runtime, security baseline (2026-05-21)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Single maintainer — every path defaults to @heznpc.
+# When the project takes outside contributors, split this by directory
+# (e.g., src/endpoints/, src/fetchers/, .github/) so PRs auto-request the
+# right reviewer.
+*       @heznpc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot v2 — github-actions ecosystem only.
+#
+# ProfileKit has zero runtime/dev npm dependencies (see package.json: no
+# `dependencies` or `devDependencies` keys), so the npm ecosystem has no
+# nodes to scan. We only track GitHub Actions versions here — actions
+# like checkout/setup-node release majors roughly yearly and we want
+# alerts when a deprecation window opens.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      # Roll non-major action updates into a single PR each month.
+      actions-minor:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,27 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege: this workflow only reads the repo and runs tests.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # Node 20 EOL'd 2026-04-30. 22 is the current Maintenance LTS
+          # (EOL 2027-04-30); 24 is Active LTS. We pin to the LTS line we
+          # test against.
+          node-version: '22'
 
       # tests/ uses the node:test runner with zero deps — no install needed.
+      - name: Syntax check
+        run: npm run check
+
       - name: Run tests
         run: npm test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 heznpc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+ProfileKit is a serverless SVG endpoint service that fetches data from
+external URLs on behalf of users. The two user-controlled URL surfaces are:
+
+- `?theme_url=` on `/api/stats` and `/api/stack` — see [`src/common/theme-url.js`](src/common/theme-url.js)
+- `?source=rss|medium&url=` on `/api/posts` — see [`src/fetchers/posts.js`](src/fetchers/posts.js)
+
+Both apply a host allowlist, https-only, `redirect: "error"`, a hard timeout,
+and a response-body size cap. If you find a bypass — or any other issue
+(prompt injection through user-controlled text, XSS in rendered SVG,
+auth/scope issue with GitHub API token pool, theme schema escape) — please
+report it privately.
+
+**How to report:**
+
+- Use GitHub's [Private vulnerability reporting](https://github.com/newtria/ProfileKit/security/advisories/new)
+  (preferred — keeps disclosure timeline tracked).
+- Or email the maintainer via the address listed on the GitHub profile.
+
+Please do **not** open a public issue for security reports.
+
+## Response timeline
+
+| Stage | Target |
+|---|---|
+| Acknowledgement | 7 days |
+| Initial assessment | 14 days |
+| Fix or mitigation plan | 30 days |
+| Coordinated disclosure | up to 90 days from report |
+
+If a fix lands before 90 days, disclosure happens at fix time. If a fix
+needs more than 90 days (e.g., upstream dependency), we coordinate a longer
+window with the reporter.
+
+## Supported versions
+
+The deployed instance at <https://profilekit.vercel.app> always runs the
+current `main` branch. There are no maintained release branches — fixes
+land on `main` and ship within minutes via Vercel.
+
+Self-hosters: re-deploy from `main` after any security advisory.
+
+## Out of scope
+
+- Denial of service via expensive `?source=rss` feeds — the per-request
+  body cap (2 MB) and timeout (5s) bound the surface; Vercel function
+  duration (10s, see `vercel.json`) is the upper bound.
+- Rate-limit consumption of the deployer's GitHub API token pool — public
+  data only, mitigated via the token pool design (`src/common/github-token.js`).
+- Issues in third-party platforms (GitHub Camo proxy, Notion image proxy,
+  etc.) that affect how cards render — report to those platforms directly.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "description": "Cards for your GitHub README. 28 composable SVG card endpoints, every visual property exposed as a query parameter. No ratings, no rankings.",
   "engines": {
-    "node": ">=20"
+    "node": ">=22 <25"
   },
   "scripts": {
-    "test": "node --test tests/*.test.js"
+    "test": "node --test tests/*.test.js",
+    "check": "node --check api/[endpoint].js && find src -name '*.js' -exec node --check {} +"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Node 20 → 22 (engines + CI). Node 20 EOL was 2026-04-30.
- CI hardening: `permissions: contents: read`, actions@v6, `npm run check` syntax pass before tests.
- Governance baseline: root `LICENSE` (MIT), `SECURITY.md`, `.github/CODEOWNERS`, Dependabot (github-actions only — zero npm deps).

## Audit pass / fail

| Item | Status |
|---|---|
| P0 Node 20 EOL | ✅ engines `>=22 <25`, CI on node 22 |
| P0 Secret scanning + push protection | follow-up via gh API |
| P1 Branch protection | follow-up via gh API after merge |
| P1 Workflow least-privilege | ✅ `permissions: contents: read` |
| P1 Dependabot (actions) | ✅ monthly, grouped non-major |
| P1 LICENSE file | ✅ MIT |
| P1 SECURITY.md | ✅ with SSRF surface map + 90-day disclosure |
| P1 CodeQL default setup | follow-up via gh API |
| P1 CI lint/format | ✅ `node --check` (zero-dep posture preserved) |
| P2 engines upper bound | ✅ `<25` |
| P2 CODEOWNERS | ✅ default @heznpc |

## Test plan
- [x] `npm run check` — passes locally on Node 22.22
- [x] `npm test` — 158/158 pass locally
- [ ] CI green on this PR