### PR TITLE
chore: simplify modernization follow-up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      # Roll non-major action updates into a single PR each month.
       actions-minor:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,19 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # engines is ">=22 <25". Node 22 is Maintenance LTS (EOL 2027-04-30);
+        # Node 24 is Active LTS. Self-hosters on either should get CI signal.
+        node-version: ['22', '24']
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
-          # Node 20 EOL'd 2026-04-30. 22 is the current Maintenance LTS
-          # (EOL 2027-04-30); 24 is Active LTS. We pin to the LTS line we
-          # test against.
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
 
       # tests/ uses the node:test runner with zero deps — no install needed.
       - name: Syntax check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,13 +26,12 @@ Please do **not** open a public issue for security reports.
 
 | Stage | Target |
 |---|---|
-| Acknowledgement | 7 days |
-| Initial assessment | 14 days |
-| Fix or mitigation plan | 30 days |
+| Acknowledgement | within 7 days |
 | Coordinated disclosure | up to 90 days from report |
 
-If a fix lands before 90 days, disclosure happens at fix time. If a fix
-needs more than 90 days (e.g., upstream dependency), we coordinate a longer
+Single-maintainer project — only the two endpoints above are committed.
+If a fix lands earlier, disclosure happens at fix time. If a fix needs
+more than 90 days (e.g., upstream dependency), we coordinate a longer
 window with the reporter.
 
 ## Supported versions

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.js",
-    "check": "node --check api/[endpoint].js && find src -name '*.js' -exec node --check {} +"
+    "check": "find api src scripts -name '*.js' -exec node --check {} +"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Code review pass on #36.

- check script: drop unquoted bash character class api/[endpoint].js
  (fragile under shopt -s failglob / zsh nomatch) and merge the two
  invocations into one find. Also picks up scripts/fetch-fonts.js,
  which the previous form silently skipped, and any future siblings
  under api/.
- ci.yml: add Node 24 to the test matrix. engines says ">=22 <25" but
  CI was only running 22 — self-hosters on 24 (Active LTS) had no
  signal. Matrix changes the required-check name to "test (22)" /
  "test (24)"; branch protection is updated alongside.
- dependabot.yml: drop the inline comment on actions-minor — restated
  what update-types already says.
- SECURITY.md: collapse the 4-row timeline to the two stages a
  single-maintainer project can actually commit to (acknowledgement,
  90-day disclosure).
