### PR TITLE
[codex] harden profilekit endpoint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Audit npm package metadata
+        run: npm audit --audit-level=high
+
   # Validates the optional self-host path: image builds, container starts,
   # HEALTHCHECK passes, /api/health responds, /api/divider returns SVG.
   # Independent of the Node matrix above because the runtime inside the

--- a/api/[endpoint].js
+++ b/api/[endpoint].js
@@ -13,8 +13,13 @@ module.exports = async (req, res) => {
     return res.send(`Unknown endpoint: ${endpoint ?? "(missing)"}`);
   }
 
-  const handler = require(`../src/endpoints/${endpoint}`);
-  return handler(req, res);
+  try {
+    const handler = require(`../src/endpoints/${endpoint}`);
+    return await handler(req, res);
+  } catch (err) {
+    res.status(500).setHeader("Content-Type", "text/plain; charset=utf-8");
+    return res.send(`Internal error: ${err.message}`);
+  }
 };
 
 module.exports.ALLOWED_ENDPOINTS = Array.from(ALLOWED).sort();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "profilekit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "profilekit",
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22 <25"
+      }
+    }
+  }
+}

--- a/tests/api-handler.test.js
+++ b/tests/api-handler.test.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const handler = require("../api/[endpoint].js");
+
+function makeReq(endpoint, params = {}) {
+  const search = new URLSearchParams(params);
+  return {
+    url: search.size ? `/api/${endpoint}?${search}` : `/api/${endpoint}`,
+    query: { ...params, endpoint },
+    method: "GET",
+    headers: { host: "profilekit.local" },
+  };
+}
+
+function makeRes() {
+  const headers = {};
+  let body = "";
+  let statusCode = 200;
+  return {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    setHeader(name, value) {
+      headers[name] = value;
+      return this;
+    },
+    send(payload) {
+      body = payload;
+      return this;
+    },
+    inspect() {
+      return { body, headers, statusCode };
+    },
+  };
+}
+
+test("Vercel dynamic handler serves /api/health", async () => {
+  const res = makeRes();
+  await handler(makeReq("health"), res);
+  const { body, headers, statusCode } = res.inspect();
+
+  assert.equal(statusCode, 200);
+  assert.match(headers["Content-Type"], /application\/json/);
+  assert.match(headers["Cache-Control"], /no-store/);
+  assert.equal(JSON.parse(body).service, "profilekit");
+});
+
+test("Vercel dynamic handler preserves user ?name= for cards", async () => {
+  const res = makeRes();
+  await handler(makeReq("hero", { name: "ProfileKit" }), res);
+  const { body, headers, statusCode } = res.inspect();
+
+  assert.equal(statusCode, 200);
+  assert.equal(headers["Content-Type"], "image/svg+xml");
+  assert.match(body, /ProfileKit/);
+});
+
+test("Vercel dynamic handler rejects unknown endpoints", async () => {
+  const res = makeRes();
+  await handler(makeReq("notreal"), res);
+  const { body, headers, statusCode } = res.inspect();
+
+  assert.equal(statusCode, 404);
+  assert.equal(headers["Content-Type"], "text/plain");
+  assert.match(body, /Unknown endpoint/);
+});
+
+test("Vercel dynamic handler returns a controlled 500 when a card throws", async () => {
+  const dividerPath = require.resolve("../src/endpoints/divider");
+  const original = require(dividerPath);
+  require.cache[dividerPath].exports = async () => {
+    throw new Error("synthetic failure");
+  };
+
+  const res = makeRes();
+  try {
+    await handler(makeReq("divider"), res);
+  } finally {
+    require.cache[dividerPath].exports = original;
+  }
+
+  const { body, headers, statusCode } = res.inspect();
+  assert.equal(statusCode, 500);
+  assert.equal(headers["Content-Type"], "text/plain; charset=utf-8");
+  assert.match(body, /Internal error: synthetic failure/);
+});


### PR DESCRIPTION
## What changed

- Add Vercel dynamic-route tests for `/api/health`, card query preservation, unknown endpoints, and controlled 500 responses.
- Wrap dynamic endpoint handler execution in a controlled 500 response path.
- Add a zero-dependency npm lockfile so `npm audit --audit-level=high` can run reliably.
- Add the npm audit gate to CI.

## Why

ProfileKit is a hosted SVG endpoint service with both Vercel and optional Docker paths. The Docker adapter already had direct route smoke coverage, but the Vercel dynamic handler needed its own regression checks. The audit command also failed without a lockfile, so the security gate was not reproducible from a clean checkout.

## Validation

- `npm run check`
- `npm test` (201 passing)
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- `docker build -t profilekit:codex-hardening .`
- Docker smoke: `/api/health` returned JSON, `/api/divider` returned `image/svg+xml`, container health became `healthy`
- Hosted smoke: `https://profilekit.vercel.app/api/health` and `/api/divider?style=line&width=400` returned 200
