### PR TITLE
Escape composer title target attributes

### DIFF
--- a/src/common/card.js
+++ b/src/common/card.js
@@ -51,11 +51,7 @@ function renderCard({ width, height, title, ariaLabel, colors, hideBorder, hideT
 
   // titleTarget is an optional data-cas-target hook for the playground
   // composer's inline-edit feature. Pure HTML attribute, no visual effect.
-  // TODO(2nd-pass-audit-2026-05-21): wrap titleTarget in escapeHtml as
-  // defense-in-depth. All current callers pass the literal "username", but
-  // an attribute interpolation without escape is a latent XSS regression
-  // path if a future caller threads user input through here.
-  const titleAttr = titleTarget ? ` data-cas-target="${titleTarget}"` : "";
+  const titleAttr = titleTarget ? ` data-cas-target="${escapeHtml(titleTarget)}"` : "";
   const titleMarkup = hideTitle
     ? ""
     : `<text x="25" y="35" class="header"${titleAttr}>${escapeHtml(title)}</text>`;

--- a/tests/cards.test.js
+++ b/tests/cards.test.js
@@ -14,6 +14,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { themes, getTheme } = require("../src/common/themes");
+const { renderCard } = require("../src/common/card");
 
 const { renderStatsCard } = require("../src/cards/stats");
 const { renderLanguagesCard } = require("../src/cards/languages");
@@ -241,4 +242,19 @@ test("smoke: accent_color override does not break renderCard cards", () => {
     const svg = render();
     assertHealthySvg(`${name} (accent override)`, svg);
   }
+});
+
+test("renderCard escapes titleTarget before interpolating data-cas-target", () => {
+  const colors = getTheme("dark");
+  const svg = renderCard({
+    width: 320,
+    height: 120,
+    title: "Safe",
+    colors,
+    body: "",
+    titleTarget: 'username" onclick="alert(1)',
+  });
+
+  assert.ok(svg.includes('data-cas-target="username&quot; onclick=&quot;alert(1)"'));
+  assert.ok(!svg.includes('data-cas-target="username" onclick="alert(1)"'));
 });


### PR DESCRIPTION
## Summary
- escape optional composer title target attributes before SVG interpolation
- add regression coverage for quote injection in `data-cas-target`

## Validation
- `npm test && npm run build && npm run smoke:server && git diff --check`